### PR TITLE
Meta hostvars

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -42,8 +42,8 @@ func gatherResources(s *state) map[string]interface{} {
 		}
 	}
 
-	groups["_meta"] = map[string]map[string]string{
-		"hostvars": make(map[string]string),
+	groups["_meta"] = map[string]map[string]interface{}{
+		"hostvars": make(map[string]interface{}),
 	}
 
 	return groups

--- a/cli.go
+++ b/cli.go
@@ -42,6 +42,10 @@ func gatherResources(s *state) map[string]interface{} {
 		}
 	}
 
+	groups["_meta"] = map[string]map[string]string{
+		"hostvars": make(map[string]string),
+	}
+
 	return groups
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -270,7 +270,9 @@ const expectedListOutput = `
 	"webserver": ["192.168.0.3"],
 	"staging": ["192.168.0.3"],
 	"status_superserver": ["10.120.0.226"],
-	"database": ["10.0.0.8"]
+	"database": ["10.0.0.8"],
+
+	"_meta": {"hostvars": {}}
 }
 `
 


### PR DESCRIPTION
## Problem

Ansible is super slow with dynamic inventories if you don't have `_meta.hostvars` present.

## Solution

Provide `_meta.hostvars` in the `--list` output.

### Background

https://github.com/ansible/ansible/issues/22633
http://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html#tuning-the-external-inventory-script